### PR TITLE
Remove Z axis rotation reading

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,6 @@ function getXRotation(x, y, z) {
 function getYRotation(x, y, z) {
 	return getRotation(x, y, z);
 }
-function getZRotation(x, y, z) {
-	return getRotation(y, z, x);
-}
 
 function scaleData(data, factor) {
 	var scaled = {};
@@ -232,8 +229,7 @@ Sensor.prototype.readRotation = function (done) {
 
 		done(null, {
 			x: getXRotation(accel.x, accel.y, accel.z),
-			y: getYRotation(accel.x, accel.y, accel.z),
-			z: getZRotation(accel.x, accel.y, accel.z)
+			y: getYRotation(accel.x, accel.y, accel.z)
 		});
 	});
 };
@@ -245,8 +241,7 @@ Sensor.prototype.readRotationSync = function (accel) {
 
 	return {
 		x: getXRotation(accel.x, accel.y, accel.z),
-		y: getYRotation(accel.x, accel.y, accel.z),
-		z: getZRotation(accel.x, accel.y, accel.z)
+		y: getYRotation(accel.x, accel.y, accel.z)
 	};
 };
 


### PR DESCRIPTION
Closes #4 

As discussed in issue #4 the Z axis rotation reading does not provide any value. It can't be derived from the sensor readings that the mpu6050 gyroscope provides.